### PR TITLE
feat/support testing environment endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ const data = await usps.getCityState({
 // }
 ```
 
+### Environment Configuration
+
+By default, the library uses the production USPS API endpoint (`https://apis.usps.com`). For development and testing purposes, you can configure the library to use the USPS Testing Environment endpoint by setting the `environment` option to `'testing'`.
+
+```javascript
+const usps = new USPS({
+  clientId: USPS_TEST_CLIENT_ID,
+  clientSecret: USPS_TEST_CLIENT_SECRET,
+  environment: 'testing', // Uses https://apis-tem.usps.com
+})
+```
+
+**Note:** You'll need separate credentials for the testing environment. Contact USPS to obtain testing environment credentials.
+
 ### Title Case Conversion
 
 The USPS v3 API returns all caps for address fields by default. This library can automatically convert the fields to a more human-readable title case if desired. To enable this feature, set the `useTitleCase` option to `true` when creating the USPS instance.

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ type CityStateResponse = {
 }
 
 export class USPS {
-  readonly baseUrl = 'https://apis.usps.com'
+  readonly baseUrl: string
   readonly clientId: string
   readonly clientSecret: string
   readonly useTitleCase: boolean
@@ -63,14 +63,20 @@ export class USPS {
     clientId = '',
     clientSecret = '',
     useTitleCase = false,
+    environment = 'production',
   }: {
     clientId?: string
     clientSecret?: string
     useTitleCase?: boolean
+    environment?: 'production' | 'testing'
   }) {
     if (!clientId || !clientSecret) {
       throw new Error('USPS clientId and clientSecret are required')
     }
+
+    this.baseUrl = environment === 'production'
+        ? 'https://apis.usps.com'
+        : 'https://apis-tem.usps.com'
 
     this.clientId = clientId
     this.clientSecret = clientSecret

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,13 +70,16 @@ export class USPS {
     useTitleCase?: boolean
     environment?: 'production' | 'testing'
   }) {
+    const productionUrl = 'https://apis.usps.com'
+    const testingUrl = 'https://apis-tem.usps.com'
+
     if (!clientId || !clientSecret) {
       throw new Error('USPS clientId and clientSecret are required')
     }
 
     this.baseUrl = environment === 'production'
-        ? 'https://apis.usps.com'
-        : 'https://apis-tem.usps.com'
+        ? productionUrl
+        : testingUrl
 
     this.clientId = clientId
     this.clientSecret = clientSecret

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -74,3 +74,22 @@ test('City/state lookup with title case', async () => {
 
   assert.strictEqual(data.city, 'Beverly Hills')
 })
+
+test('uses testing environment endpoint when environment is testing', () => {
+  const uspsTest = new USPS({
+    clientId: process.env.USPS_CLIENT_ID,
+    clientSecret: process.env.USPS_CLIENT_SECRET,
+    environment: 'testing',
+  })
+
+  assert.strictEqual(uspsTest.baseUrl, 'https://apis-tem.usps.com')
+})
+
+test('uses production environment endpoint by default', () => {
+  const uspsProd = new USPS({
+    clientId: process.env.USPS_CLIENT_ID,
+    clientSecret: process.env.USPS_CLIENT_SECRET,
+  })
+
+  assert.strictEqual(uspsProd.baseUrl, 'https://apis.usps.com')
+})


### PR DESCRIPTION
This PR handles the issue described [here](https://github.com/balancer-team/usps-v3-js/issues/1)

It adds an optional `environment`  parameter to the constructor to allow developers to switch between `production` and `testing` endpoints.

It also adds respective tests scenarios to cover this new feature.
<img width="643" height="380" alt="Screenshot 2026-01-21 at 12 38 51 PM" src="https://github.com/user-attachments/assets/32c17849-5f7e-48c6-a773-13e8733d0e35" />
